### PR TITLE
fix(store): generate a unique id per Store instance

### DIFF
--- a/src/HTeaLeaf/State/Store.py
+++ b/src/HTeaLeaf/State/Store.py
@@ -76,8 +76,8 @@ class SuperStore:
 
 
 class Store:
-    def __init__(self, default={}, subscribe=True, id=str(uuid4())):
-        self._id = id
+    def __init__(self, default={}, subscribe=True, id=None):
+        self._id = id if id is not None else str(uuid4())
         self.data = copy.copy(default)
         self.js = JSCode(f"store_{self._id[:8]}")
         if subscribe:


### PR DESCRIPTION
## Problem

`Store.__init__` defaults `id` to `str(uuid4())`:

```python
def __init__(self, default={}, subscribe=True, id=str(uuid4())):
```

Default arguments are evaluated **once, at import time**, so every `Store` created without an explicit `id` receives the *same* UUID. Each then registers under that same key in `SuperStore.stores` (`add()` overwrites), so two independent default-constructed stores collapse into one endpoint — `/api/_store/{id}/*` traffic for store A is served by whichever store registered last.

## Fix

Default `id=None` and generate the UUID inside `__init__`:

```python
def __init__(self, default={}, subscribe=True, id=None):
    self._id = id if id is not None else str(uuid4())
```

## Verification

```
a, b = Store(), Store()   -> a._id != b._id   ✓
Store(id="x")._id == "x"                        ✓
```

No API change; explicit ids still honored (incl. `AuthStore`, which passes `id=self._id`).