### PR TITLE
fix(store): scope react() class by path, not the id builtin

### DIFF
--- a/src/HTeaLeaf/State/Store.py
+++ b/src/HTeaLeaf/State/Store.py
@@ -132,7 +132,7 @@ class Store:
         return pointer
 
     def react(self, path) -> Component:
-        return div(self.read(path)).classes(f"{self._id}{id}_react")
+        return div(self.read(path)).classes(f"{self._id}{path}_react")
 
     def create(self, path: str, data):
         path_list = path.split("/") if path != "" else []


### PR DESCRIPTION
## Problem

`Store.react()` builds the reactive element's class from `{id}` — Python's built-in `id` function — instead of the `path` argument:

```python
def react(self, path) -> Component:
    return div(self.read(path)).classes(f"{self._id}{id}_react")
```

This produces a class like `...<built-in function id>_react`. Meanwhile `helper.js` looks up nodes to update by class `store_id + path + "_react"` (helper.js:98-99), so the class never matches and partial re-render silently fails — only the heavier full-page `fetch_front()` reconciliation keeps the counter limping along.

## Fix

```python
return div(self.read(path)).classes(f"{self._id}{path}_react")
```

## Verification

```
Store({"count":0}, id="s1").react("count").attributes["class"] == "s1count_react"  ✓
```

matching `this.store_id + id + "_react"` in helper.js.