### PR TITLE
fix(renderer): HTML-escape text and attribute output (XSS)

### DIFF
--- a/src/HTeaLeaf/Elements/Renderer/html.py
+++ b/src/HTeaLeaf/Elements/Renderer/html.py
@@ -1,3 +1,4 @@
+import html
 from typing import Any
 
 from HTeaLeaf.JS.JSCode import JSCode
@@ -6,6 +7,10 @@ from ..Component import Component
 from ..Elements import script
 from .render_context import get_render_ctx
 from .renderer import Renderer
+
+# Elements whose text content is CDATA in HTML and must not be escaped,
+# otherwise inline JS/CSS (e.g. injected @js functions) would break.
+RAW_TEXT_TAGS = {"script", "style"}
 
 
 class HTMLRenderer(Renderer[str]):
@@ -18,14 +23,16 @@ class HTMLRenderer(Renderer[str]):
 
         def __build_attr__(cmpt: Component) -> str:
             return " " + " ".join(
-                f"{k}='{v}'" if v is not None else f"{k}"
+                f"{k}='{html.escape(str(v), quote=True)}'" if v is not None else f"{k}"
                 for k, v in cmpt.attributes.items()
             )
 
         if len(cmpt.children) == 0:
             result = f"<{cmpt.name}{__build_attr__(cmpt)}/>\n"
         else:
-            inner_result = self.render(cmpt.children, subrender=True)
+            inner_result = self.render(
+                cmpt.children, subrender=True, raw_text=cmpt.name in RAW_TEXT_TAGS
+            )
             result = f"<{cmpt.name}{__build_attr__(cmpt)}>\n"
             if cmpt.styles is not None:
                 self.css[cmpt.id] = cmpt.styles
@@ -37,6 +44,7 @@ class HTMLRenderer(Renderer[str]):
         self,
         cmpt: Component | list | str | JSCode | Any,
         subrender=False,
+        raw_text=False,
     ) -> str:
 
         if not subrender:
@@ -50,14 +58,14 @@ class HTMLRenderer(Renderer[str]):
 
         html_parts = []
         if isinstance(cmpt, str):
-            html_parts.append(f"{cmpt}")
+            html_parts.append(cmpt if raw_text else html.escape(cmpt))
         elif isinstance(cmpt, list):
             for child in cmpt:
-                html = self.render(child, subrender=True)
-                html_parts.append(html)
+                rendered = self.render(child, subrender=True, raw_text=raw_text)
+                html_parts.append(rendered)
         elif isinstance(cmpt, Component):
-            html = self.__render_component__(cmpt)
-            html_parts.append(html)
+            rendered = self.__render_component__(cmpt)
+            html_parts.append(rendered)
         elif isinstance(cmpt, JSCode):
             # JSCode outside of an attribute should be a special tag {{jscode_name}}
             html_parts.append(f"{{{{{cmpt.raw}}}}}")


### PR DESCRIPTION
## Problem

The HTML renderer interpolates attribute values and text nodes with raw f-strings and performs **no escaping anywhere** (`grep -rn "escape\|sanitize" src/` → nothing). Any client-writable data that reaches the DOM is a stored-XSS vector — most directly, `Store.react()` renders store values that any client can write via `PATCH /api/_store/{id}/{path}`. A payload like `<img src=x onerror=...>` executes for every visitor.

## Fix

- Escape text nodes and attribute values with `html.escape(..., quote=True)`.
- Keep `<script>`/`<style>` content **raw** via a `raw_text` flag threaded through `render()`, so injected inline JS (the `@js` functions and store initializers) and CSS are not corrupted.
- Rename a local variable that would otherwise shadow the new `html` module import.

Secure-by-default; a future opt-out for intentionally-trusted raw HTML can be layered on top.

## Verification

```
div("<img src=x onerror=alert(1)>")  -> "&lt;img ..."          (escaped)   ✓
div("x").attr(title="a'b<c")         -> "&#x27;", "&lt;c"       (escaped)   ✓
script('if (a < b) foo("x");')       -> "a < b", 'foo("x")'     (raw)       ✓
```