### PR TITLE
fix(server): prevent session fixation via client-chosen cookie

### DIFF
--- a/src/HTeaLeaf/Server/Server.py
+++ b/src/HTeaLeaf/Server/Server.py
@@ -177,16 +177,13 @@ class Server:
 
     def __handle_session__(self, cookies: dict):
         header_session_cookie = None
-        if cookies.get(COOKIE_NAME) is None:
+        session_id = cookies.get(COOKIE_NAME)
+        # Never adopt a client-supplied session id we didn't issue: an unknown
+        # or missing cookie starts a fresh server-generated session and the new
+        # id is set on the response, preventing session fixation.
+        if session_id is None or self.sessions.get(session_id) is None:
             session_id = self.__create_session__()
             header_session_cookie = ("Set-Cookie", f"{COOKIE_NAME}={session_id}")
-        else:
-            session_id = cookies[COOKIE_NAME]
-            if self.sessions.get(session_id) is None:
-                self.sessions[session_id] = Session()
-                self.__call_hook__(
-                    ServerEvent.new_session, session_id, self.sessions[session_id]
-                )
 
         return self.sessions[session_id], header_session_cookie
 


### PR DESCRIPTION
## Problem

`Server.__handle_session__` trusted the client's session cookie value. When the cookie held an id the server didn't know, it created a session **under that attacker-chosen id** and issued no new `Set-Cookie`:

```python
else:
    session_id = cookies[COOKIE_NAME]
    if self.sessions.get(session_id) is None:
        self.sessions[session_id] = Session()
        ...
```

That is the textbook session-fixation setup: an attacker pins a victim's cookie to a known id, waits for the victim to authenticate, then reuses it. (Id *generation* via `uuid4()` is fine — the flaw is accepting client-supplied ids.)

## Fix

Treat a missing or unrecognized cookie identically: mint a fresh server-generated id and set it on the response. A client can never bind a session to an id it chose.

```python
session_id = cookies.get(COOKIE_NAME)
if session_id is None or self.sessions.get(session_id) is None:
    session_id = self.__create_session__()
    header_session_cookie = ("Set-Cookie", f"{COOKIE_NAME}={session_id}")
```

## Verification

- Forged/unknown id → not adopted, fresh id issued ✓
- Known server id → preserved, no re-issue ✓
- No cookie → new session ✓

Follow-up worth doing separately: add `HttpOnly`/`Secure`/`SameSite` flags to the session cookie.