### PR TITLE
fix(server): session hardening — Secure cookie, session cap, thread-safety

### DIFF
--- a/src/htealeaf/server/adapter/asgi.py
+++ b/src/htealeaf/server/adapter/asgi.py
@@ -85,6 +85,7 @@ async def ASGI(
         headers=headers,
         body=body,
         body_handler=body_handler,
+        is_ssl=scope.get("scheme") == "https",
     )
 
     response = await handler(request)

--- a/src/htealeaf/server/adapter/wsgi.py
+++ b/src/htealeaf/server/adapter/wsgi.py
@@ -34,7 +34,10 @@ def WSGI(handler: Callable[[Request], Awaitable[Response]],environ: dict[str, An
     else:
         raise Exception(f"Invalid body format: {type(input_)}")
 
-    request = Request(method, path, headers=headers, body=body, body_handler=None)
+    is_ssl = environ.get("wsgi.url_scheme") == "https"
+    request = Request(
+        method, path, headers=headers, body=body, body_handler=None, is_ssl=is_ssl
+    )
     response = asyncio.run(handler(request))
     start_response(response.status.to_str(), to_list(response.headers))
     response_body: bytes = (

--- a/src/htealeaf/server/session.py
+++ b/src/htealeaf/server/session.py
@@ -1,3 +1,4 @@
+import threading
 from dataclasses import dataclass
 from time import time
 from typing import OrderedDict
@@ -37,27 +38,35 @@ class Session:
 
 
 class SessionManager:
-    def __init__(self, max_ttl=10_000) -> None:
+    def __init__(self, max_ttl=10_000, max_sessions=100_000) -> None:
         self.sessions: OrderedDict[str, Session] = OrderedDict()
         self.max_ttl = max_ttl
+        self.max_sessions = max_sessions
         self.next_eviction = time() + self.max_ttl
+        # Guards self.sessions against concurrent access under threaded WSGI,
+        # where the app is invoked from multiple threads sharing this manager.
+        self._lock = threading.Lock()
 
     def create(self, session_id=None):
         """Generates a unique session ID."""
         session_id = session_id or str(uuid4())
         exp = time() + self.max_ttl
 
-        self.sessions[session_id] = Session(exp)
-        self.sessions.move_to_end(session_id)
+        with self._lock:
+            self.sessions[session_id] = Session(exp)
+            self.sessions.move_to_end(session_id)
+            self._enforce_limit()
         return session_id
 
     def exist(self, session_id):
-        session = self.sessions.get(session_id)
+        with self._lock:
+            session = self.sessions.get(session_id)
         if session is None or session.ttl() == 0:
             return False
         return True
 
     def _check_evict(self):
+        """Drop expired sessions from the front of the LRU. Caller holds the lock."""
         while self.sessions:
             session_id, session = next(iter(self.sessions.items()))
 
@@ -67,16 +76,25 @@ class SessionManager:
 
             self.sessions.popitem(last=False)
 
-    def get(self, session_id):
-        session = self.sessions.get(session_id)
-        if session is None:
-            return None
-        if session.ttl() == 0:
-            del self.sessions[session_id]
-            return None
+    def _enforce_limit(self):
+        """Cap the number of live sessions, evicting LRU first. Caller holds the lock."""
+        if len(self.sessions) <= self.max_sessions:
+            return
+        self._check_evict()
+        while len(self.sessions) > self.max_sessions:
+            self.sessions.popitem(last=False)
 
-        session.exp = time() + self.max_ttl
-        self.sessions.move_to_end(session_id)
-        if time() > self.next_eviction:
-            self._check_evict()
-        return session
+    def get(self, session_id):
+        with self._lock:
+            session = self.sessions.get(session_id)
+            if session is None:
+                return None
+            if session.ttl() == 0:
+                del self.sessions[session_id]
+                return None
+
+            session.exp = time() + self.max_ttl
+            self.sessions.move_to_end(session_id)
+            if time() > self.next_eviction:
+                self._check_evict()
+            return session


### PR DESCRIPTION
Security hardening on the session engine, from the `develop` security review. Three related fixes:

- **#30** — the session cookie is now flagged `Secure` when the request arrived over HTTPS. Neither adapter populated `is_ssl`, so `Secure` was never emitted and the session id could travel over plaintext HTTP. ASGI reads `scope['scheme']`, WSGI reads `environ['wsgi.url_scheme']`.
- **#31** — `SessionManager` now caps live sessions (`max_sessions`, default 100k) and evicts LRU (expired first). Previously any cookie-less request minted a session with no cap, held for the full TTL (~2.7h) — an unauthenticated memory-exhaustion vector.
- **#32** — the `sessions` OrderedDict is now guarded by a `threading.Lock`; it was mutated unsynchronized, which corrupts under threaded WSGI (app invoked from multiple threads).

### Validation
Smoke-tested locally: cap keeps newest / evicts oldest; expired sessions are dropped by `get`/`exist`; 8 threads × 500 create/get/exist stay within the cap with no crash; `Secure` appears only under `https` on both WSGI and ASGI (`HttpOnly`/`SameSite=Lax` preserved).

Closes #30, #31, #32.