### PR TITLE
fix(server): HTTP request parsing robustness — query string, body size, decode

### DIFF
--- a/src/htealeaf/server/adapter/asgi.py
+++ b/src/htealeaf/server/adapter/asgi.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Iterable, Literal, Optional
+from urllib.parse import parse_qsl
 
 from ..http import Headers, Request, Response
 from .adapter import adapter
@@ -72,11 +73,9 @@ async def ASGI(
     if root and path.startswith(root):
         path = path[len(root) :] or "/"
 
-    args_kv = scope["query_string"].decode().split("&") if scope["query_string"] else []
-    args = {}
-    for kv in args_kv:
-        k, v = kv.split("=", 1)
-        args[k] = v
+    args = dict(
+        parse_qsl(scope["query_string"].decode(), keep_blank_values=True)
+    )
     body_handler = receive if more_body else None
     request = Request(
         scope["method"],

--- a/src/htealeaf/server/adapter/wsgi.py
+++ b/src/htealeaf/server/adapter/wsgi.py
@@ -5,6 +5,9 @@ from .adapter import adapter
 
 from ..http import Headers, Request, Response
 
+# Cap the request body read so a large upload can't exhaust server memory.
+MAX_BODY_SIZE = 10 * 1024 * 1024  # 10 MiB
+
 
 def to_list(headers: Headers) -> list[tuple[str, str]]:
     return [h for h in headers]
@@ -26,7 +29,12 @@ def WSGI(handler: Callable[[Request], Awaitable[Response]],environ: dict[str, An
     if input_ is None:
         body = None
     elif hasattr(input_, "read"):
-        body = input_.read()
+        body = input_.read(MAX_BODY_SIZE + 1)
+        if len(body) > MAX_BODY_SIZE:
+            start_response(
+                "413 Payload Too Large", [("Content-Type", "text/plain")]
+            )
+            return iter([b"Payload Too Large"])
     elif isinstance(input_, bytes):
         body = input_
     elif isinstance(input_, str):

--- a/src/htealeaf/server/http/request.py
+++ b/src/htealeaf/server/http/request.py
@@ -55,23 +55,30 @@ class HttpRequest:
         if content_length is None:
             return None
 
-        body_size = int(content_length or 0)
-        if body_size == 0 or self.body is None:
+        try:
+            body_size = int(content_length)
+        except (TypeError, ValueError):
             return None
-        if isinstance(self.body, io.BufferedReader):
-            if not self.body.closed and self.body.readable():
-                return self.body.read(body_size).decode("utf-8")
-            else:
-                return None
-        elif isinstance(self.body, bytes):
-            return self.body.decode("utf-8")
-        elif isinstance(self.body, str):
+        if body_size <= 0 or self.body is None:
+            return None
+
+        if isinstance(self.body, str):
             return self.body
+        elif isinstance(self.body, io.BufferedReader):
+            if self.body.closed or not self.body.readable():
+                return None
+            raw = self.body.read(body_size)
+        elif isinstance(self.body, bytes):
+            raw = self.body
         elif hasattr(self.body, "__iter__"):
-            result = b"".join([d for d in iter(self.body)])
-            return result.decode("utf-8")
+            raw = b"".join([d for d in iter(self.body)])
         else:
             raise ValueError(f"Invalid body type: {type(self.body)}")
+
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
 
     def form(self) -> dict[str, str] | None:
         """


### PR DESCRIPTION
Robustness fixes on request parsing, from the `develop` security review. Independent of #36 (verified both branches merge cleanly into `develop` in either order).

- **#34** — the ASGI adapter parsed the query string with `k, v = kv.split('=', 1)`, which raised `ValueError` on a valueless param (`?debug`) → 500 before the handler ran, and never percent-decoded values. Now uses `urllib.parse.parse_qsl(..., keep_blank_values=True)`, matching the CGI adapter.
- **#35** — the WSGI adapter read the whole body with `input_.read()` and no cap (memory-exhaustion vector); it now reads at most `MAX_BODY_SIZE` (10 MiB) and returns **413** when exceeded. `__body_to_text__` decoded with a bare `.decode('utf-8')` and `int(content_length)`, so a non-UTF-8 body or non-numeric `Content-Length` raised → 500; both are guarded and return `None`, so `json()`/`form()` degrade gracefully.

### Validation
Smoke-tested locally: `?debug` → `{'debug': ''}`, `?q=a%20b` → `{'q': 'a b'}`; oversized WSGI body → 413, normal body → 200; invalid-UTF-8 body and non-numeric Content-Length → `text()/json()/form()` return `None` with no exception.

Closes #34, #35.