### PR TITLE
fix(server): propagate render context to sync handlers in executor

### DIFF
--- a/src/htealeaf/server/server.py
+++ b/src/htealeaf/server/server.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import functools
 import inspect
 import json
@@ -232,9 +233,12 @@ class Server:
             if inspect.iscoroutinefunction(handler):
                 response = await handler(**params)
             else:
-                # response = handler(**params) # Run syncronously for now
+                # copy_context so the render context (a ContextVar) set by
+                # init_render_ctx is visible inside the executor thread;
+                # otherwise use_state()/@js registrations are silently lost
+                context = contextvars.copy_context()
                 response = await asyncio.get_event_loop().run_in_executor(
-                    None, functools.partial(handler, **params)
+                    None, functools.partial(context.run, handler, **params)
                 )
 
             response = self.__process_response__(response)


### PR DESCRIPTION
## Problem

`use_state()` and `@js` are silently broken inside **sync** route handlers.

```python
@app.route("/")
def index():                      # sync
    count = use_state(0)
    @js
    def increment():
        count.set(count.get() + 1)
    return html(head(), body(h1("Count: ", count), button("+").attr(onclick=increment())))
```

The response ships an empty `<head />` — no `LocalState` initializer, no transpiled function — so the page shows a raw `{{localstate_…}}` placeholder and `onclick` calls an undefined function. The same handler declared `async def` works.

## Cause

`handle_request` stores the render context in a `ContextVar` (`init_render_ctx`) and then runs sync handlers via `loop.run_in_executor(...)`. `run_in_executor` does not propagate `contextvars`, so inside the worker thread `get_render_ctx()` returns `None` and every registration is dropped without error.

## Fix

Run the handler through `contextvars.copy_context()`:

```python
context = contextvars.copy_context()
response = await asyncio.get_event_loop().run_in_executor(
    None, functools.partial(context.run, handler, **params)
)
```

The copied context sees the same `RenderContext` object, so registrations made in the executor thread are visible when the main thread renders the response. Async handlers are unaffected.

## Verification

Reproduced on `develop` (60e7e1f) with uvicorn + curl: before the patch the sync handler renders `<head />`; after it, both `<script>` blocks (state initializer + transpiled `increment`) are injected and identical to the async handler's output. `ruff check` passes.